### PR TITLE
PHP 4 style constructors deprecated in PHP 7

### DIFF
--- a/bfstop.php
+++ b/bfstop.php
@@ -30,7 +30,7 @@ class plgSystembfstop extends JPlugin
 		return (int)$this->params->get($paramName, $default);
 	}
 
-	function plgSystembfstop(& $subject, $config) 
+	function __construct(& $subject, $config) 
 	{
 		parent::__construct($subject, $config);
 	}


### PR DESCRIPTION
Methods with the same name as their class will not be constructors in a future version of PHP.

See http://php.net/manual/en/migration70.deprecated.php
